### PR TITLE
Fix TypeError in MonthWidget for optional dates

### DIFF
--- a/monthyear/widgets.py
+++ b/monthyear/widgets.py
@@ -40,6 +40,8 @@ class MonthSelectorWidget(widgets.MultiWidget):
         datelist = [
             widget.value_from_datadict(data, files, name + '_%s' % i)
             for i, widget in enumerate(self.widgets)]
+        if not datelist[0] or not datelist[1]:
+            return None
         try:
             D = date(day=1, month=int(datelist[0]),
                      year=int(datelist[1]))

--- a/payroll/forms.py
+++ b/payroll/forms.py
@@ -99,6 +99,10 @@ class EmployeeProfileForm(forms.ModelForm):
                 }
             ),
         }
+        extra_kwargs = {
+            'date_of_birth': {'required': False},
+            'date_of_employment': {'required': False},
+        }
         # exclude = ["created",]
 
 


### PR DESCRIPTION
I resolved a `TypeError` in `monthyear/widgets.py` that occurred when you submitted forms with optional `MonthField` (e.g., `date_of_birth`, `date_of_employment` in `EmployeeProfileForm`) left blank.

The `MonthSelectorWidget.value_from_datadict` method was updated to gracefully handle `None` or empty string values for month or year components before attempting conversion with `int()`. If essential date parts are missing, the widget now correctly returns `None`.

Additionally, `required=False` was explicitly set for these date fields in `EmployeeProfileForm` via `Meta.extra_kwargs` for clarity and robustness, ensuring they are treated as optional at the form level.