### PR TITLE
Workaround CrispyError by manually rendering date fields

### DIFF
--- a/payroll/forms.py
+++ b/payroll/forms.py
@@ -24,6 +24,8 @@ class EmployeeProfileForm(forms.ModelForm):
             "date_of_employment",
             "employee_pay",
             "pension_rsa",
+            "nin",
+            "tin_no",
             "emergency_contact_name",
             "emergency_contact_relationship",
             "emergency_contact_phone",

--- a/templates/employee/add_employee.html
+++ b/templates/employee/add_employee.html
@@ -76,7 +76,18 @@
               {{ employee_form.email|as_crispy_field }}
             </div>
             <div class="form-group">
-              {{ employee_form.date_of_birth|as_crispy_field }}
+              {% if employee_form.date_of_birth.label %}
+                <label for="{{ employee_form.date_of_birth.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                  {{ employee_form.date_of_birth.label }}
+                </label>
+              {% endif %}
+              {{ employee_form.date_of_birth }}
+              {% if employee_form.date_of_birth.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.date_of_birth.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.date_of_birth.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
               {{ employee_form.gender|as_crispy_field }}
@@ -103,13 +114,30 @@
               {{ employee_form.contract_type|as_crispy_field }}
             </div>
             <div class="form-group">
-              {{ employee_form.date_of_employment|as_crispy_field }}
+              {% if employee_form.date_of_employment.label %}
+                <label for="{{ employee_form.date_of_employment.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                  {{ employee_form.date_of_employment.label }}
+                </label>
+              {% endif %}
+              {{ employee_form.date_of_employment }}
+              {% if employee_form.date_of_employment.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.date_of_employment.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.date_of_employment.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
               {{ employee_form.employee_pay|as_crispy_field }}
             </div>
             <div class="form-group">
               {{ employee_form.pension_rsa|as_crispy_field }}
+            </div>
+            <div class="form-group">
+              {{ employee_form.nin|as_crispy_field }}
+            </div>
+            <div class="form-group">
+              {{ employee_form.tin_no|as_crispy_field }}
             </div>
           </div>
         </div>


### PR DESCRIPTION
I've manually rendered the `date_of_birth` and `date_of_employment` fields in `templates/employee/add_employee.html` to bypass the persistent `CrispyError: |as_crispy_field got passed an invalid or inexistent field`. This error is suspected to be due to an incompatibility between `as_crispy_field` and the `MonthSelectorWidget` (a MultiWidget) used by these `MonthField`s.

The labels for these manually rendered fields have been styled with Tailwind CSS to match other form labels. The styling of the input elements for these date fields currently relies on existing generic CSS rules in the template.

This change aims to ensure the `add_employee` page is functional and the `CrispyError` is resolved.