### PR TITLE
Fix CrispyError by manually rendering employee_form

### DIFF
--- a/templates/employee/add_employee.html
+++ b/templates/employee/add_employee.html
@@ -67,13 +67,46 @@
           <div class="space-y-4"> {# Changed gap-6 to gap-4 (implicitly via space-y) #}
             <h3 class="text-xl font-semibold text-gray-900">Personal Details</h3>
             <div class="form-group">
-              {{ employee_form.first_name|as_crispy_field }}
+              {% if employee_form.first_name.label %}
+              <label for="{{ employee_form.first_name.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.first_name.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.first_name }}
+              {% if employee_form.first_name.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.first_name.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.first_name.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.last_name|as_crispy_field }}
+              {% if employee_form.last_name.label %}
+              <label for="{{ employee_form.last_name.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.last_name.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.last_name }}
+              {% if employee_form.last_name.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.last_name.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.last_name.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.email|as_crispy_field }}
+              {% if employee_form.email.label %}
+              <label for="{{ employee_form.email.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.email.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.email }}
+              {% if employee_form.email.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.email.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.email.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
               {% if employee_form.date_of_birth.label %}
@@ -90,14 +123,48 @@
               {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.gender|as_crispy_field }}
+              {% if employee_form.gender.label %}
+              <label for="{{ employee_form.gender.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.gender.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.gender }}
+              {% if employee_form.gender.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.gender.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.gender.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.phone|as_crispy_field }}
-              <p class="text-sm text-gray-500 mt-1">Example: +1234567890</p>
+              {% if employee_form.phone.label %}
+              <label for="{{ employee_form.phone.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.phone.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.phone }}
+              {% if employee_form.phone.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.phone.help_text }}</p>
+              {% else %}
+                <p class="text-sm text-gray-500 mt-1">Example: +1234567890</p>
+              {% endif %}
+              {% for error in employee_form.phone.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.address|as_crispy_field }}
+              {% if employee_form.address.label %}
+              <label for="{{ employee_form.address.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.address.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.address }}
+              {% if employee_form.address.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.address.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.address.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
           </div>
 
@@ -105,13 +172,46 @@
           <div class="space-y-4"> {# Changed gap-6 to gap-4 (implicitly via space-y) #}
             <h3 class="text-xl font-semibold text-gray-900">Employment Details</h3>
             <div class="form-group">
-              {{ employee_form.department|as_crispy_field }}
+              {% if employee_form.department.label %}
+              <label for="{{ employee_form.department.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.department.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.department }}
+              {% if employee_form.department.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.department.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.department.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.job_title|as_crispy_field }}
+              {% if employee_form.job_title.label %}
+              <label for="{{ employee_form.job_title.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.job_title.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.job_title }}
+              {% if employee_form.job_title.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.job_title.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.job_title.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.contract_type|as_crispy_field }}
+              {% if employee_form.contract_type.label %}
+              <label for="{{ employee_form.contract_type.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.contract_type.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.contract_type }}
+              {% if employee_form.contract_type.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.contract_type.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.contract_type.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
               {% if employee_form.date_of_employment.label %}
@@ -128,16 +228,60 @@
               {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.employee_pay|as_crispy_field }}
+              {% if employee_form.employee_pay.label %}
+              <label for="{{ employee_form.employee_pay.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.employee_pay.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.employee_pay }}
+              {% if employee_form.employee_pay.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.employee_pay.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.employee_pay.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.pension_rsa|as_crispy_field }}
+              {% if employee_form.pension_rsa.label %}
+              <label for="{{ employee_form.pension_rsa.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.pension_rsa.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.pension_rsa }}
+              {% if employee_form.pension_rsa.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.pension_rsa.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.pension_rsa.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.nin|as_crispy_field }}
+              {% if employee_form.nin.label %}
+              <label for="{{ employee_form.nin.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.nin.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.nin }}
+              {% if employee_form.nin.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.nin.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.nin.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.tin_no|as_crispy_field }}
+              {% if employee_form.tin_no.label %}
+              <label for="{{ employee_form.tin_no.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.tin_no.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.tin_no }}
+              {% if employee_form.tin_no.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.tin_no.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.tin_no.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
           </div>
         </div>
@@ -147,14 +291,48 @@
           <h3 class="text-xl font-semibold text-blue-800">Emergency Contact Information</h3>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4"> {# Changed gap-6 to gap-4 #}
             <div class="form-group">
-              {{ employee_form.emergency_contact_name|as_crispy_field }}
+              {% if employee_form.emergency_contact_name.label %}
+              <label for="{{ employee_form.emergency_contact_name.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.emergency_contact_name.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.emergency_contact_name }}
+              {% if employee_form.emergency_contact_name.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.emergency_contact_name.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.emergency_contact_name.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.emergency_contact_relationship|as_crispy_field }}
+              {% if employee_form.emergency_contact_relationship.label %}
+              <label for="{{ employee_form.emergency_contact_relationship.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.emergency_contact_relationship.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.emergency_contact_relationship }}
+              {% if employee_form.emergency_contact_relationship.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.emergency_contact_relationship.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.emergency_contact_relationship.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.emergency_contact_phone|as_crispy_field }}
-              <p class="text-sm text-gray-500 mt-1">Example: +1234567890</p>
+              {% if employee_form.emergency_contact_phone.label %}
+              <label for="{{ employee_form.emergency_contact_phone.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.emergency_contact_phone.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.emergency_contact_phone }}
+              {% if employee_form.emergency_contact_phone.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.emergency_contact_phone.help_text }}</p>
+              {% else %}
+                <p class="text-sm text-gray-500 mt-1">Example: +1234567890</p>
+              {% endif %}
+              {% for error in employee_form.emergency_contact_phone.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
           </div>
         </div>
@@ -164,14 +342,48 @@
           <h3 class="text-xl font-semibold text-blue-800">Next of Kin Information</h3>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4"> {# Changed gap-6 to gap-4 #}
             <div class="form-group">
-              {{ employee_form.next_of_kin_name|as_crispy_field }}
+              {% if employee_form.next_of_kin_name.label %}
+              <label for="{{ employee_form.next_of_kin_name.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.next_of_kin_name.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.next_of_kin_name }}
+              {% if employee_form.next_of_kin_name.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.next_of_kin_name.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.next_of_kin_name.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.next_of_kin_relationship|as_crispy_field }}
+              {% if employee_form.next_of_kin_relationship.label %}
+              <label for="{{ employee_form.next_of_kin_relationship.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.next_of_kin_relationship.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.next_of_kin_relationship }}
+              {% if employee_form.next_of_kin_relationship.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.next_of_kin_relationship.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.next_of_kin_relationship.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.next_of_kin_phone|as_crispy_field }}
-              <p class="text-sm text-gray-500 mt-1">Example: +1234567890</p>
+              {% if employee_form.next_of_kin_phone.label %}
+              <label for="{{ employee_form.next_of_kin_phone.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.next_of_kin_phone.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.next_of_kin_phone }}
+              {% if employee_form.next_of_kin_phone.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.next_of_kin_phone.help_text }}</p>
+              {% else %}
+                <p class="text-sm text-gray-500 mt-1">Example: +1234567890</p>
+              {% endif %}
+              {% for error in employee_form.next_of_kin_phone.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
           </div>
         </div>
@@ -181,14 +393,48 @@
           <h3 class="text-xl font-semibold text-blue-800">Banking Information</h3>
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4"> {# Changed gap-6 to gap-4 #}
             <div class="form-group">
-              {{ employee_form.bank|as_crispy_field }}
+              {% if employee_form.bank.label %}
+              <label for="{{ employee_form.bank.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.bank.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.bank }}
+              {% if employee_form.bank.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.bank.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.bank.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.bank_account_name|as_crispy_field }}
+              {% if employee_form.bank_account_name.label %}
+              <label for="{{ employee_form.bank_account_name.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.bank_account_name.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.bank_account_name }}
+              {% if employee_form.bank_account_name.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.bank_account_name.help_text }}</p>
+              {% endif %}
+              {% for error in employee_form.bank_account_name.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
             <div class="form-group">
-              {{ employee_form.bank_account_number|as_crispy_field }}
-              <p class="text-sm text-gray-500 mt-1">Enter your account number</p>
+              {% if employee_form.bank_account_number.label %}
+              <label for="{{ employee_form.bank_account_number.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+                {{ employee_form.bank_account_number.label }}
+              </label>
+              {% endif %}
+              {{ employee_form.bank_account_number }}
+              {% if employee_form.bank_account_number.help_text %}
+                <p class="text-sm text-gray-500 mt-1">{{ employee_form.bank_account_number.help_text }}</p>
+              {% else %}
+                <p class="text-sm text-gray-500 mt-1">Enter your account number</p>
+              {% endif %}
+              {% for error in employee_form.bank_account_number.errors %}
+                <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+              {% endfor %}
             </div>
           </div>
         </div>
@@ -199,8 +445,20 @@
             <svg class="w-12 h-12 mx-auto text-gray-400 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"></path>
             </svg>
-            {{ employee_form.photo|as_crispy_field }} {# Crispy will add its own label, this might look odd without custom widget #}
-            <p class="mt-2 text-sm text-gray-500">PNG, JPG up to 2MB</p>
+            {% if employee_form.photo.label %}
+            <label for="{{ employee_form.photo.id_for_label }}" class="block text-sm font-medium text-gray-500 mb-1">
+              {{ employee_form.photo.label }}
+            </label>
+            {% endif %}
+            {{ employee_form.photo }}
+            {% if employee_form.photo.help_text %}
+              <p class="text-sm text-gray-500 mt-1">{{ employee_form.photo.help_text }}</p>
+            {% else %}
+              <p class="mt-2 text-sm text-gray-500">PNG, JPG up to 2MB</p>
+            {% endif %}
+            {% for error in employee_form.photo.errors %}
+              <p class="text-xs text-red-600 mt-1">{{ error }}</p>
+            {% endfor %}
           </div>
         </div>
 


### PR DESCRIPTION
Resolves the persistent `CrispyError` on the add_employee page by removing the use of the `|as_crispy_field` filter for all fields within the `employee_form`. These fields are now rendered manually in `templates/employee/add_employee.html` using standard Django template tags for labels, widgets, help text, and errors.

This change gives more direct control over rendering and avoids potential incompatibilities between the `as_crispy_field` filter and specific field types or widgets within the `employee_form`.

Styling for the manually rendered fields aims for consistency with the rest of the form by leveraging existing CSS rules. The `user_form` on the same page continues to use `as_crispy_field`.